### PR TITLE
ui: 侧边栏菜单区改为可滚动，修复工作区增多时设置项被挤出屏幕

### DIFF
--- a/dsh-mobile-app/lib/main.dart
+++ b/dsh-mobile-app/lib/main.dart
@@ -291,24 +291,32 @@ class _RootScreenState extends State<RootScreen> with WidgetsBindingObserver {
                   ],
                 ),
               ),
-              const SizedBox(height: 4),
-              // 工作区快速切换（对齐 PC 端 workspace 切换；≥2 个工作区时显示）
-              if (store.workspaces.length >= 2) ...[
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
-                  child: Text(
-                    '工作区',
-                    style: TextStyle(fontSize: 11.5, fontWeight: FontWeight.w600, letterSpacing: 0.5, color: DshColors.ink3(context)),
-                  ),
+              // 中间菜单区：可滚动 —— 工作区数量增多时，导航项（含「设置」）不再被挤出屏幕，
+              // 也无需删除工作区才能进入设置区；头部（新建会话）与底部（连接状态）保持固定。
+              Expanded(
+                child: ListView(
+                  padding: EdgeInsets.zero,
+                  children: [
+                    const SizedBox(height: 4),
+                    // 工作区快速切换（对齐 PC 端 workspace 切换；≥2 个工作区时显示）
+                    if (store.workspaces.length >= 2) ...[
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
+                        child: Text(
+                          '工作区',
+                          style: TextStyle(fontSize: 11.5, fontWeight: FontWeight.w600, letterSpacing: 0.5, color: DshColors.ink3(context)),
+                        ),
+                      ),
+                      _workspaceItem(null),
+                      for (final w in store.workspaces) _workspaceItem(w),
+                      const SizedBox(height: 8),
+                    ],
+                    _drawerItem(Icons.home_outlined, '首页', 0),
+                    _drawerItem(Icons.history, '会话', 1),
+                    _drawerItem(Icons.settings_outlined, '设置', 2),
+                  ],
                 ),
-                _workspaceItem(null),
-                for (final w in store.workspaces) _workspaceItem(w),
-                const SizedBox(height: 8),
-              ],
-              _drawerItem(Icons.home_outlined, '首页', 0),
-              _drawerItem(Icons.history, '会话', 1),
-              _drawerItem(Icons.settings_outlined, '设置', 2),
-              const Spacer(),
+              ),
               Padding(
                 padding: const EdgeInsets.all(16),
                 child: Text(


### PR DESCRIPTION
## 问题现象

注册工作区数量较多时，侧边栏（抽屉）底部的「设置」按钮被挤出屏幕：

- 抽屉主体是固定高度的 `Column`，**不可滚动**；
- 每个工作区占约 46px，加上头部（~90px）与三个导航项，总高超过屏幕后「设置」被推出可视区；
- `Spacer()` 在空间不足时收缩为 0，无法兜底；
- 用户无法滑动抽屉，**只能删除工作区**才能重新进入设置页。

## 根因

`dsh-mobile-app/lib/main.dart` 的 `Drawer` 使用 `Column` 静态布局，工作区列表（`for (final w in store.workspaces) _workspaceItem(w)`）无上限地增长，超出屏幕高度后底部导航项溢出。

## 修复方案

抽屉改为「头部/底部固定 + 中间菜单区滚动」：

- 头部（DSH logo + 新建会话按钮）与底部（连接状态文字）保持固定，不随菜单滚动；
- 中间菜单区（工作区列表 + 首页/会话/设置）包进 `Expanded(child: ListView(...))`；
- 工作区再多也能滚动到「设置」，无需删除工作区。

改动集中在 `dsh-mobile-app/lib/main.dart` 的 Drawer 部分，约 25 行（+25/−17），无其他文件受影响。

## 验证

- 已做括号配对静态检查通过；
- 未跑真机/模拟器验证（本机无 Flutter 环境），建议合并后构建一版快速回归：工作区数量超过一屏 → 抽屉可滚动、设置可达、头部新建会话按钮与底部状态文字位置正常。